### PR TITLE
Fix Research Reinvented load order

### DIFF
--- a/ResearchReinvented_SteppingStones/About/About.xml
+++ b/ResearchReinvented_SteppingStones/About/About.xml
@@ -28,6 +28,7 @@
 	<loadAfter>
 		<li>brrainz.harmony</li>
 		<li>imranfish.xmlextensions</li>
+		<li>PeteTimesSix.ResearchReinvented</li>
 	</loadAfter>
 	<description>
 Restructures the vanilla research tree to follow a more logical progression.


### PR DESCRIPTION
Research Reinvented: Stepping Stones will fail to apply some of its patches and will show errors in the log if it is loaded before Research Reinvented. This PR adds this restriction to the About file.