### PR TITLE
explicit prerequisities for starting Dubs Bad Hygiene techs

### DIFF
--- a/ResearchReinvented_SteppingStones/LoadFolders.xml
+++ b/ResearchReinvented_SteppingStones/LoadFolders.xml
@@ -22,5 +22,6 @@
 		<li IfModActive="ludeon.rimworld.biotech">ModSpecific/v1.5/_Biotech</li>
 		<li IfModActive="ludeon.rimworld.anomaly">ModSpecific/v1.5/_Anomaly</li>
 		<li IfModActive="oskarpotocki.vfe.tribals">ModSpecific/v1.5/VFE_Tribals</li>
+		<li IfModActive="Dubwise.DubsBadHygiene">ModSpecific/v1.5/DubsBadHygiene</li>
 	</v1.5>
 </loadFolders>

--- a/ResearchReinvented_SteppingStones/ModSpecific/v1.5/DubsBadHygiene/Patches/ResearchProjectDefs.xml
+++ b/ResearchReinvented_SteppingStones/ModSpecific/v1.5/DubsBadHygiene/Patches/ResearchProjectDefs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="RR.PatchOperationAddOrReplace">
+		<xpath>Defs/ResearchProjectDef[defName="LogBoilers"]</xpath>
+		<value>
+			<prerequisites>
+			  <li>RR_Fire</li>
+			</prerequisites>
+		</value>
+	</Operation>
+	<Operation Class="RR.PatchOperationAddOrReplace">
+		<xpath>/Defs/ResearchProjectDef[defName="SewageSludgeComposting"]</xpath>
+		<value>
+			<prerequisites>
+			  <li>RR_Agriculture</li>
+			</prerequisites>
+		</value>
+	</Operation>
+	<Operation Class="RR.PatchOperationAddOrReplace">
+		<xpath>Defs/ResearchProjectDef[defName="Plumbing"]</xpath>
+		<value>
+			<prerequisites>
+			  <li>Smithing</li>
+			</prerequisites>
+		</value>
+	</Operation>
+</Patch>


### PR DESCRIPTION
My primary motivation for these is making it simpler to research the techs if I have 'theory' research disabled. These introduce some parts from the prerequsities into research for the techs, without them reverse engineering is a significant portion of the research, and since there are no existing items from the mod yet, it's hard to finish the research for these techs.
Also, I play with no starting research, and at least plumbing should definitely depend on something later than the starting lateral thinking, given that it's obviously medieval.
